### PR TITLE
[fix] work properly with url.parse()

### DIFF
--- a/lib/jsonquest.js
+++ b/lib/jsonquest.js
@@ -1,6 +1,11 @@
+var http = require('http'),
+    https = require('https');
+    
 var protocols = {
-  'http': require('http'),
-  'https': require('https')
+  'http': http,
+  'http:': http,
+  'https': https,
+  'https:': https
 };
 
 module.exports = function (options, callback) {
@@ -8,7 +13,7 @@ module.exports = function (options, callback) {
       req;
 
   req = protocol.request({
-    host: options.host,
+    host: options.hostname || options.host,
     port: options.port,
     path: options.path,
     auth: options.auth,


### PR DESCRIPTION
Allows an parsed url object to be directly passed into jsonquest (with the other required attributes of course
